### PR TITLE
Update firewall.user

### DIFF
--- a/files/etc/firewall.user
+++ b/files/etc/firewall.user
@@ -7,4 +7,4 @@
 # special user chains, e.g. input_wan_rule or postrouting_lan_rule.
 iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-ports 53
 iptables -t nat -A PREROUTING -p tcp --dport 53 -j REDIRECT --to-ports 53
-iptables -t nat -I POSTROUTING -j MASQUERADE
+iptables -t nat -I POSTROUTING -o eth0 -j MASQUERADE


### PR DESCRIPTION
添加 -o eth0 选项可能有助于解决部分旁路由无法正常转发流量的问题。该问题在 openfans-community-offical/Debian-Pi-Aarch64 项目发行的 2021-11-11-OPENFANS-Debian-Buster-Aarch64-ext4-v2021-2.0-U6-Release-plus++ 镜像（Kernel 5.10.78; Docker version 20.10.7, build f0df350）中必现，使用设备为 树莓派4B，使用镜像版本为 sulinggg/openwrt:rpi4，镜像 DIGEST 为 4892351796bf。